### PR TITLE
replaced system_timer with timeout because ruby1.9 incompatibility issue

### DIFF
--- a/bin/AWScloudwatchEC2.rb
+++ b/bin/AWScloudwatchEC2.rb
@@ -8,7 +8,7 @@ require 'Sendit'
 require 'rubygems'
 require 'fog'
 require 'optparse'
-require 'system_timer'
+require 'timeout'
 
 # Start back 15m by default
 #  Instances with detailed monitoring will generally have 10+ metrics for this offset
@@ -98,7 +98,7 @@ instance_list.each do |i|
     responses = ''
     metrics.each do |metric|
       begin
-        SystemTimer.timeout_after($cloudwatchtimeout) do
+        Timeout::timeout($cloudwatchtimeout) do
           responses = cloudwatch.get_metric_statistics({
                            'Statistics' => metric[:stat],
                            'StartTime'  => startTime.iso8601,

--- a/lib/SendGraphite.rb
+++ b/lib/SendGraphite.rb
@@ -1,12 +1,12 @@
 ## send it 
 require 'socket'
-require 'system_timer'
+require 'timeout'
 
 def SendGraphite(metricpath, metricvalue, metrictimestamp)
   retries = $graphiteretries
   message = ''
   begin
-  	SystemTimer.timeout_after($graphitetimeout) do 
+  	Timeout::timeout($graphitetimeout) do
 	    message = metricpath + " " + metricvalue.to_s + " " + metrictimestamp.to_s
 	    #puts message
 	    sock = TCPSocket.new($graphiteserver, $graphiteport)


### PR DESCRIPTION
I replaced the system_timer with default timer.
