### PR TITLE
Improve Error Handling in bin/NewrelicThresholds.rb

### DIFF
--- a/bin/NewrelicThresholds.rb
+++ b/bin/NewrelicThresholds.rb
@@ -29,6 +29,8 @@ def GetThresholdMetrics(application, appname)
 
 	body=response.body_str
 	data = XmlSimple.xml_in(body, { 'KeyAttr' => 'threshold_values' })
+	raise 'No data returned from New Relic API' if data['content'] === "\n"
+	raise "Error returned from New Relic API: #{data['content']}" if data['content']
 	data['threshold_value'].each do |item|
 	Sendit "newrelic." + appname.gsub( /[ \.]/, "_") + "." + item['name'].gsub(" ","_"), item['metric_value'], $timenow.to_s
 	end


### PR DESCRIPTION
Just a couple of small fixes to bin/NewrelicThresholds.rb
1. Raise errors when no data is returned from New Relic.
2. Report friendly error messages on failure
