### PR TITLE
Allow optional graphite prefix

### DIFF
--- a/conf/config.rb-sample
+++ b/conf/config.rb-sample
@@ -51,6 +51,7 @@ $tw_access_token_secret = ''
 
 # Graphite
 # $graphiteserver = '127.0.0.1'
+$graphiteprefix = ''
 $graphiteserver = ''
 $graphiteport = 2003
 $graphiteretries = 3

--- a/lib/SendGraphite.rb
+++ b/lib/SendGraphite.rb
@@ -10,6 +10,7 @@ end
 
 def SendGraphite(metricpath, metricvalue, metrictimestamp)
   retries = $graphiteretries
+  metricpath = "#{$graphiteprefix}.#{metricpath}" if $graphiteprefix && !$graphiteprefix.empty?
   message = ''
   begin
   	SomeTimer.timeout($graphitetimeout) do


### PR DESCRIPTION
Added support to prepend a string to metrics before sending
to graphite.
