### PR TITLE
Add support for - AWS IAM roles for instances

### DIFF
--- a/bin/AWScloudwatchBilling.rb
+++ b/bin/AWScloudwatchBilling.rb
@@ -40,7 +40,7 @@ startTime = Time.now.utc - options[:start_offset].to_i
 endTime  = Time.now.utc - options[:end_offset].to_i
 
 
-cloudwatch = Fog::AWS::CloudWatch.new(:aws_secret_access_key => $awssecretkey, :aws_access_key_id => $awsaccesskey)
+cloudwatch = Fog::AWS::CloudWatch.new($awscredential)
 
 %w( AmazonCloudFront AmazonDynamoDB AmazonEC2 AmazonRDS AmazonS3 AmazonSNS AWSDataTransfer ).each do |name|
   responses = cloudwatch.get_metric_statistics({

--- a/bin/AWScloudwatchDynamo.rb
+++ b/bin/AWScloudwatchDynamo.rb
@@ -81,7 +81,7 @@ operationLevelMetrics = [
 ]
 
 
-cloudwatch = Fog::AWS::CloudWatch.new(:aws_secret_access_key => $awssecretkey, :aws_access_key_id => $awsaccesskey)
+cloudwatch = Fog::AWS::CloudWatch.new($awscredential)
 
 tables.each do |table|
   operationLevelMetrics.each do |metric|

--- a/bin/AWScloudwatchEBS.rb
+++ b/bin/AWScloudwatchEBS.rb
@@ -47,7 +47,7 @@ if ARGV.length > 0
     volumeIds << vol
   end
 else
-  compute = Fog::Compute.new(:provider => :aws, :aws_secret_access_key => $awssecretkey, :aws_access_key_id => $awsaccesskey)
+  compute = Fog::Compute.new($awscredential.merge({:provider => :aws}))
   compute.volumes.all.each do |vol|
     volumeIds << vol.id
   end
@@ -106,7 +106,7 @@ metrics = [
     }
 ]
 
-cloudwatch = Fog::AWS::CloudWatch.new(:aws_secret_access_key => $awssecretkey, :aws_access_key_id => $awsaccesskey)
+cloudwatch = Fog::AWS::CloudWatch.new($awscredential)
 
 volumeIds.each do |volume|
   metrics.each do |metric|
@@ -137,4 +137,3 @@ volumeIds.each do |volume|
     end
   end
 end
-

--- a/bin/AWScloudwatchEC2.rb
+++ b/bin/AWScloudwatchEC2.rb
@@ -48,12 +48,8 @@ optparse.parse!
 startTime = Time.now.utc - options[:start_offset].to_i
 endTime   = Time.now.utc - options[:end_offset].to_i
 
-compute     = Fog::Compute.new( :provider => :aws,
-              :aws_access_key_id => $awsaccesskey,
-              :aws_secret_access_key => $awssecretkey)
-cloudwatch  = Fog::AWS::CloudWatch.new(
-              :aws_access_key_id => $awsaccesskey,
-              :aws_secret_access_key => $awssecretkey)
+compute     = Fog::Compute.new($awscredential.merge({:provider => :aws}))
+cloudwatch  = Fog::AWS::CloudWatch.new($awscredential)
 
 instance_list = compute.servers.all
 

--- a/bin/AWScloudwatchELB.rb
+++ b/bin/AWScloudwatchELB.rb
@@ -69,7 +69,7 @@ metricNames = {"RequestCount" => "Sum",
 
 unit = 'Count'
 
-cloudwatch = Fog::AWS::CloudWatch.new(:aws_secret_access_key => $awssecretkey, :aws_access_key_id => $awsaccesskey, :region => $awsregion)
+cloudwatch = Fog::AWS::CloudWatch.new($awscredential.merge({:region => $awsregion}))
 
 lbs.each do |table|
   metricNames.each do |metricName, statistic|
@@ -110,7 +110,7 @@ metricNames = {"Maximum" => "Latency",
 
 unit = 'Seconds'
 
-cloudwatch = Fog::AWS::CloudWatch.new(:aws_secret_access_key => $awssecretkey, :aws_access_key_id => $awsaccesskey)
+cloudwatch = Fog::AWS::CloudWatch.new($awscredential)
 
 lbs.each do |table|
   metricNames.each do |statistic, metricName|
@@ -142,4 +142,3 @@ lbs.each do |table|
     end
   end
 end
-

--- a/bin/AWScloudwatchRDS.rb
+++ b/bin/AWScloudwatchRDS.rb
@@ -46,7 +46,7 @@ if ARGV.length > 0
     dbNames << db
   end
 else
-  rds = Fog::AWS::RDS.new(:aws_secret_access_key => $awssecretkey, :aws_access_key_id => $awsaccesskey)
+  rds = Fog::AWS::RDS.new($awscredential)
   rds.servers.all.each do |s|
     dbNames << s.id
   end
@@ -71,7 +71,7 @@ metricNames = {"CPUUtilization" => "Percent",
 }
 
 
-cloudwatch = Fog::AWS::CloudWatch.new(:aws_secret_access_key => $awssecretkey, :aws_access_key_id => $awsaccesskey)
+cloudwatch = Fog::AWS::CloudWatch.new($awscredential)
 
 dbNames.each do |db|
   metricNames.each do |metricName, unit|

--- a/bin/AWScountEC2.rb
+++ b/bin/AWScountEC2.rb
@@ -13,9 +13,7 @@ require 'Sendit'
 require 'rubygems' if RUBY_VERSION < "1.9"
 require 'fog'
 
-compute = Fog::Compute.new(	:provider => :aws,
-							:aws_access_key_id => $awsaccesskey,
-							:aws_secret_access_key => $awssecretkey)
+compute = Fog::Compute.new($awscredential.merge({:provider => :aws}))
 
 instance_list		= compute.servers.all
 instance_report	= Hash.new

--- a/conf/config.rb-sample
+++ b/conf/config.rb-sample
@@ -10,11 +10,20 @@ $newrelicaccount = ''
 # $newrelicapikey = '123123123123123123123'
 $newrelicapikey = ''
 
-# AWS
-# $awsaccesskey = 'AAAAAAAAAAAAAAAA'
-$awsaccesskey = ''
-# $awssecretkey = 'aaaaaaaaaaaaaaaaaaaaaaaaaa'
-$awssecretkey = ''
+# AWS Crendential - Using Keys
+# $awscredential = {
+#   :aws_secret_access_key => 'aaaaaaaaaaaaaaaaaaaaaaaaaa',
+#   :aws_access_key_id => 'AAAAAAAAAAAAAAAA'
+# }
+$awscredential = {
+  :aws_secret_access_key => '',
+  :aws_access_key_id => ''
+}
+# AWS Crendential - Using IAM instance profile
+# If using IAM profile: i) uncomment following & ii) comment "Using Keys" section above
+# $awscredential = {
+#   :use_iam_profile => true
+# }
 # $awsregion = 'us-east-1'
 $awsregion = 'us-east-1'
 
@@ -63,7 +72,7 @@ $gmondport = 8649
 
 ##OpenTSDB You'll need to manually tell tsdb about each top level metric you add like this:
 ## tsdb mkmetric newrelic
-## tsdb mkmetric AWScloudwatch 
+## tsdb mkmetric AWScloudwatch
 # $opentsdbserver = '127.0.0.1'
 $opentsdbserver = ''
 $opentsdbport = 4242


### PR DESCRIPTION
For obvious reasons using IAM role is better than hardcoding aws keys in your code.
More: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
