### PR TITLE
Need ruby-dev in order to install fog gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is a good thing to do because whilst all the external SAAS services we use 
 ## Install dependancies
 ### Debian/Ubuntu
 
-    apt-get install ruby build-essential libcurl3 libcurl3-gnutls libcurl4-openssl-dev
+    apt-get install ruby ruby-dev build-essential libcurl3 libcurl3-gnutls libcurl4-openssl-dev
 
 ### Amazon Linux
 


### PR DESCRIPTION
Without ruby-dev on Ubuntu 14.04, running gem install fog causes the following error:
```
 $ sudo gem install fog

Building native extensions.    This could take a while...
ERROR:    Error installing fog:
ERROR: Failed to build gem native extension.
/usr/bin/ruby1.9.1 extconf.rb
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
from extconf.rb:4:in `<main>'
```